### PR TITLE
Fixes bug: WampHandler failure on invalid JSON.

### DIFF
--- a/lib/wamp_server.dart
+++ b/lib/wamp_server.dart
@@ -33,7 +33,16 @@ class WampHandler implements StreamConsumer {
     clients.add(c);
 
     socket.listen((data) {
-      final msg = JSON.decode(data);
+      
+      var msg;
+      
+      try {
+        msg = JSON.decode(data);
+      } on FormatException {
+        socket.close(WebSocketStatus.UNSUPPORTED_DATA, 'Received data is not a valid JSON.');
+        
+        return;
+      }
 
       switch(msg[0]) {
         case MessageType.PREFIX:
@@ -60,6 +69,7 @@ class WampHandler implements StreamConsumer {
       c.topics.forEach((t) => _unsubscribe(c, t));
       clients.remove(c);
     });
+
   }
 
 


### PR DESCRIPTION
Uncaught exception on invalid JSON destroys a server.
I am not sure this is the best solution. But it works. And it's better than fail of a server.

Do you have another idea?
