### PR TITLE
Updates browser to >=0.10.0+2 <0.11.0 and moves it to the dev_dependencies.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,5 +6,7 @@ homepage: https://github.com/gmosx/dart-wamp
 environment:
   sdk: ">=0.8.10+6 <2.0.0"
 dependencies:
-  browser: ">=0.9.0 < 0.10.0"
   uuid: ">=0.3.2 <0.4.0"
+dev_dependencies:
+  browser: ">=0.10.0+2 <0.11.0"
+  


### PR DESCRIPTION
We need `browser` package to run examples.
I moved it to the `dev_dependencies`.

I done it because received the conflict of browser's version with another package.
